### PR TITLE
Allow builds to override final build result

### DIFF
--- a/vars/runBuild.groovy
+++ b/vars/runBuild.groovy
@@ -90,9 +90,11 @@ def call(Map config, Closure body) {
         }
 
         body()
-        
-        stage('Mark build as success') {
-            currentBuild.result = "SUCCESS"
+
+        stage('Mark build as success (if not already set)') {
+            if (currentBuild.result == null){
+                currentBuild.result = "SUCCESS"
+            }
         }
     } catch (InterruptedException e) {
         // Build interupted


### PR DESCRIPTION
- Sometimes a build might want to mark a build as unstable. If a build has set a previous build result we should not override it with 'success'